### PR TITLE
Add request body streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,3 +651,5 @@ This project exists thanks to all the people who contribute. [[Contributors](htt
 ## 📃 License
 
 Apache License Version 2.0 see http://www.apache.org/licenses/LICENSE-2.0.html
+
+

--- a/ext-src/stubs/php_swoole_http_request.stub.php
+++ b/ext-src/stubs/php_swoole_http_request.stub.php
@@ -7,6 +7,8 @@ namespace Swoole\Http {
 		public function parse(string $data): int|false {}
 		public function isCompleted(): bool {}
 		public function getMethod(): string|false {}
-		public function getContent(): string|false {}
-	}
+                public function getContent(): string|false {}
+                /** @return resource|false */
+                public function getBodyStream(){}
+        }
 }

--- a/ext-src/stubs/php_swoole_http_request.stub.php
+++ b/ext-src/stubs/php_swoole_http_request.stub.php
@@ -7,8 +7,8 @@ namespace Swoole\Http {
 		public function parse(string $data): int|false {}
 		public function isCompleted(): bool {}
 		public function getMethod(): string|false {}
-                public function getContent(): string|false {}
-                /** @return resource|false */
-                public function getBodyStream(){}
-        }
+		public function getContent(): string|false {}
+		/** @return resource|false */
+		public function getBodyStream() {}
+	}
 }

--- a/ext-src/stubs/php_swoole_http_request_arginfo.h
+++ b/ext-src/stubs/php_swoole_http_request_arginfo.h
@@ -21,3 +21,6 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Swoole_Http_Request_getMethod arginfo_class_Swoole_Http_Request_getData
 
 #define arginfo_class_Swoole_Http_Request_getContent arginfo_class_Swoole_Http_Request_getData
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Swoole_Http_Request_getBodyStream, 0, 0, MAY_BE_RESOURCE|MAY_BE_FALSE)
+ZEND_END_ARG_INFO()

--- a/ext-src/swoole_http_request.cc
+++ b/ext-src/swoole_http_request.cc
@@ -222,7 +222,7 @@ const zend_function_entry swoole_http_request_methods[] =
     PHP_ME(swoole_http_request, parse,                      arginfo_class_Swoole_Http_Request_parse,       ZEND_ACC_PUBLIC)
     PHP_ME(swoole_http_request, isCompleted,                arginfo_class_Swoole_Http_Request_isCompleted, ZEND_ACC_PUBLIC)
     PHP_ME(swoole_http_request, getMethod,                  arginfo_class_Swoole_Http_Request_getMethod,   ZEND_ACC_PUBLIC)
-    PHP_ME(swoole_http_request, getBodyStream,              arginfo_class_Swoole_Http_Request_getBodyStream, ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_http_request, getBodyStream,           arginfo_class_Swoole_Http_Request_getBodyStream,  ZEND_ACC_PUBLIC)
     PHP_FE_END
 };
 // clang-format on

--- a/ext-src/swoole_http_request.cc
+++ b/ext-src/swoole_http_request.cc
@@ -918,33 +918,37 @@ static PHP_METHOD(swoole_http_request, getBodyStream) {
         RETURN_FALSE;
     }
 
-    char tmp_file[SW_HTTP_UPLOAD_TMPDIR_SIZE];
-    sw_snprintf(tmp_file, SW_HTTP_UPLOAD_TMPDIR_SIZE, "%s/swoole.request.XXXXXX", ctx->upload_tmp_dir.c_str());
-    int fd = swoole_tmpfile(tmp_file);
-    if (fd < 0) {
-        RETURN_FALSE;
-    }
-
     HttpRequest *req = &ctx->request;
+    const char *data = nullptr;
+    size_t length = 0;
+
     if (req->body_length > 0) {
         zval *zdata = &req->zdata;
-        write(fd, Z_STRVAL_P(zdata) + Z_STRLEN_P(zdata) - req->body_length, req->body_length);
+        data = Z_STRVAL_P(zdata) + Z_STRLEN_P(zdata) - req->body_length;
+        length = req->body_length;
     } else if (req->chunked_body && req->chunked_body->length != 0) {
-        write(fd, req->chunked_body->str, req->chunked_body->length);
+        data = req->chunked_body->str;
+        length = req->chunked_body->length;
     } else if (req->h2_data_buffer && req->h2_data_buffer->length != 0) {
-        write(fd, req->h2_data_buffer->str, req->h2_data_buffer->length);
+        data = req->h2_data_buffer->str;
+        length = req->h2_data_buffer->length;
     }
 
-    lseek(fd, 0, SEEK_SET);
-    php_stream *stream = php_swoole_create_stream_from_pipe(fd, "r+", nullptr);
+    zend_string *buf = nullptr;
+    if (data && length > 0) {
+        buf = zend_string_init(data, length, 0);
+    }
+    php_stream *stream = php_stream_memory_open(TEMP_STREAM_READONLY, buf);
     if (!stream) {
-        close(fd);
+        if (buf) {
+            zend_string_release(buf);
+        }
         RETURN_FALSE;
     }
-    zval *ztmpfiles = swoole_http_init_and_read_property(
-        swoole_http_request_ce, ctx->request.zobject, &ctx->request.ztmpfiles, SW_ZSTR_KNOWN(SW_ZEND_STR_TMPFILES));
-    add_next_index_string(ztmpfiles, tmp_file);
     php_stream_to_zval(stream, return_value);
+    if (buf) {
+        zend_string_release(buf);
+    }
 }
 
 static PHP_METHOD(swoole_http_request, getData) {

--- a/ext-src/swoole_http_request.cc
+++ b/ext-src/swoole_http_request.cc
@@ -222,7 +222,7 @@ const zend_function_entry swoole_http_request_methods[] =
     PHP_ME(swoole_http_request, parse,                      arginfo_class_Swoole_Http_Request_parse,       ZEND_ACC_PUBLIC)
     PHP_ME(swoole_http_request, isCompleted,                arginfo_class_Swoole_Http_Request_isCompleted, ZEND_ACC_PUBLIC)
     PHP_ME(swoole_http_request, getMethod,                  arginfo_class_Swoole_Http_Request_getMethod,   ZEND_ACC_PUBLIC)
-    PHP_ME(swoole_http_request, getBodyStream,             arginfo_class_Swoole_Http_Request_getBodyStream, ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_http_request, getBodyStream,              arginfo_class_Swoole_Http_Request_getBodyStream, ZEND_ACC_PUBLIC)
     PHP_FE_END
 };
 // clang-format on

--- a/tests/swoole_http_server/getBodyStream.phpt
+++ b/tests/swoole_http_server/getBodyStream.phpt
@@ -1,0 +1,46 @@
+--TEST--
+swoole_http_server: getBodyStream
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_in_valgrind();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use function Co\run;
+
+$pm = new ProcessManager;
+$pm->parentFunc = function ($pid) use ($pm) {
+    run(function () use ($pm) {
+        $randomData = get_safe_random();
+        $cli = new Co\http\Client(HTTP_SERVER_HOST, $pm->getFreePort(), false);
+        $cli->setMethod('POST');
+        $cli->setData($randomData);
+        $ok = $cli->execute('/getBodyStream');
+        Assert::assert($ok);
+        Assert::same($cli->statusCode, 200);
+        Assert::same($cli->errCode, 0);
+        Assert::same($cli->body, $randomData);
+        $pm->kill();
+        echo "DONE\n";
+    });
+};
+$pm->childFunc = function () use ($pm) {
+    $http = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $http->set(['worker_num' => 1]);
+    $http->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
+        $stream = $request->getBodyStream();
+        $response->end(stream_get_contents($stream));
+    });
+    $http->start();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
## Summary
- remove previous issue-2373 docs
- add `getBodyStream()` method for `Swoole\Http\Request`
- document method in stubs and arginfo
- test new streaming method

## Testing
- `./run-core-tests.sh` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6866aa5649dc832794e177a01462b64d